### PR TITLE
fix: input image

### DIFF
--- a/packages/vue/src/input.vue
+++ b/packages/vue/src/input.vue
@@ -59,7 +59,8 @@ function handleDataTransfer(event: Event, transfer: DataTransfer | null) {
 
     const reader = new FileReader()
     reader.addEventListener('load', function () {
-      emit('send', segment(type, { src: reader.result }).toString())
+      const type1 = type === 'image' ? 'img' : type
+      emit('send', segment(type1, { src: reader.result }).toString())
     }, false)
     reader.readAsDataURL(file)
   }


### PR DESCRIPTION
https://github.com/satorijs/components/blob/main/packages/vue/src/input.vue#L47C1-L66C2
![QQ_1739799548734](https://github.com/user-attachments/assets/cbbe747d-9bc2-40fd-aac7-ccbf4ae87e96)
如果 segment 传入的 type 是 "image"，会导致沙盒无法通过粘贴或拖拽的方式输入图片。
![image](https://github.com/user-attachments/assets/efb8e30b-420a-4cee-931a-d00518508a01)